### PR TITLE
Binary Lookup Optimizations

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -3,9 +3,40 @@ package core
 import (
 	"os/exec"
 	"sort"
+	"sync"
 
 	"github.com/evilsocket/islazy/str"
 )
+
+var (
+	preLookupTable = make(map[string]bool)   // used to indicate if we have the executable already looked up
+	preLookupPaths = make(map[string]string) // used to hold the paths for executables that we already have looked up
+	preLookupLock  sync.RWMutex
+)
+
+// PopulatePreLookupTable is used to pre-populate a list of
+// commonly used executables along with their executable paths
+// to avoid spending time repeatedly doing this
+func PopulatePreLookupTable(lookups ...string) {
+	for _, lookup := range lookups {
+		if HasBinary(lookup) {
+			preLookupLock.Lock()
+			preLookupTable[lookup] = true
+			preLookupLock.Unlock()
+			path, err := exec.LookPath(lookup)
+			if err != nil {
+				panic("HasBinary returned true but LookPath failed, this is unexpected")
+			}
+			if path != "" {
+				preLookupLock.Lock()
+				preLookupPaths[lookup] = path
+				preLookupLock.Unlock()
+			}
+		} else {
+			continue
+		}
+	}
+}
 
 func UniqueInts(a []int, sorted bool) []int {
 	tmp := make(map[int]bool, len(a))
@@ -27,6 +58,15 @@ func UniqueInts(a []int, sorted bool) []int {
 }
 
 func HasBinary(executable string) bool {
+	// first check lookup table
+	preLookupLock.RLock()
+	has := preLookupTable[executable]
+	preLookupLock.RUnlock()
+	if has {
+		return true
+	}
+	// ok we dont have this in the prelookup table so take the slow-route
+	// of looking it up on disk
 	if path, err := exec.LookPath(executable); err != nil || path == "" {
 		return false
 	}
@@ -34,9 +74,20 @@ func HasBinary(executable string) bool {
 }
 
 func Exec(executable string, args []string) (string, error) {
-	path, err := exec.LookPath(executable)
-	if err != nil {
-		return "", err
+	var (
+		path string
+		err  error
+	)
+	preLookupLock.RLock()
+	path = preLookupPaths[executable]
+	preLookupLock.Unlock()
+	// we dont have this in the pre-lookup table
+	// so take the slow route of looking it up on disk
+	if path == "" {
+		path, err = exec.LookPath(executable)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	raw, err := exec.Command(path, args...).CombinedOutput()

--- a/core/core.go
+++ b/core/core.go
@@ -27,13 +27,9 @@ func PopulatePreLookupTable(lookups ...string) {
 			if err != nil {
 				panic("HasBinary returned true but LookPath failed, this is unexpected")
 			}
-			if path != "" {
-				preLookupLock.Lock()
-				preLookupPaths[lookup] = path
-				preLookupLock.Unlock()
-			}
-		} else {
-			continue
+			preLookupLock.Lock()
+			preLookupPaths[lookup] = path
+			preLookupLock.Unlock()
 		}
 	}
 }

--- a/core/core.go
+++ b/core/core.go
@@ -80,7 +80,7 @@ func Exec(executable string, args []string) (string, error) {
 	)
 	preLookupLock.RLock()
 	path = preLookupPaths[executable]
-	preLookupLock.Unlock()
+	preLookupLock.RUnlock()
 	// we dont have this in the pre-lookup table
 	// so take the slow route of looking it up on disk
 	if path == "" {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -218,3 +218,32 @@ func TestPopulatePreLookupTable(t *testing.T) {
 		})
 	}
 }
+
+// used to benchmark the effect of the binary lookup cache
+func BenchmarkCachedExeLookup(b *testing.B) {
+	b.StopTimer()
+	// reset the lookup table for this benchmark
+	preLookupTable = make(map[string]bool)
+	// cache the binary
+	PopulatePreLookupTable("iw")
+	// reset timer and other information
+	b.ResetTimer()
+	// start the timer
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = HasBinary("iw")
+	}
+}
+
+// used to benchmark the effect of not using a binary lookup cache
+func BenchmarkDirectExeLookup(b *testing.B) {
+	b.StopTimer()
+	// reset the lookup table
+	preLookupTable = make(map[string]bool)
+	// reset timer and other information
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = HasBinary("iw")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,10 @@ import (
 )
 
 func main() {
+	// populate binary lookup table for frequently checked binaries
+	// this should lead to measurable improvements in wifi channel hopping
+	core.PopulatePreLookupTable("iw", "iwconfig")
+
 	sess, err := session.New()
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
This change enables an optimization for bettercap usage on linux devices. Linux devices with bettercap repeatedly lookup `iw` and `iwconfig` during a variety of conditions, namely when hopping wifi channels. Previously we would check with the OS each and every time. On Raspberry Pi's this lead to a measurable amount of time (according to pprof) that was spent looking this information up.

This PR should fix the situation by populating this information once at startup to avoid repeated lookups.